### PR TITLE
game: Expand visual dimension

### DIFF
--- a/Game/Player/Player.tscn
+++ b/Game/Player/Player.tscn
@@ -769,7 +769,7 @@ scale = Vector2( 0.229429, 0.193287 )
 texture = ExtResource( 2 )
 vframes = 3
 hframes = 48
-frame = 15
+frame = 71
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 rotation = -1.5708
@@ -804,18 +804,19 @@ parameters/Run/blend_position = Vector2( 0, 1 )
 
 [node name="HitboxPivot" type="Position2D" parent="."]
 position = Vector2( 0, -4 )
-rotation = 4.71239
+rotation = 1.5708
 __meta__ = {
 "_gizmo_extents_": 8.0
 }
 
 [node name="SwordHitbox" parent="HitboxPivot" instance=ExtResource( 3 )]
-position = Vector2( 13.9989, 0.33371 )
+position = Vector2( 20.9921, 0.33371 )
 collision_mask = 8
 script = ExtResource( 4 )
 
 [node name="CollisionShape2D" parent="HitboxPivot/SwordHitbox" index="0"]
-position = Vector2( -0.667393, -0.3337 )
+visible = false
+position = Vector2( 0.333751, 0.333719 )
 shape = SubResource( 47 )
 disabled = true
 

--- a/Game/World.tscn
+++ b/Game/World.tscn
@@ -567,10 +567,10 @@ tile_data = PoolIntArray( -1, 0, 0, -65536, 0, 1, -65535, 0, 1, -65534, 0, 1, -6
 position = Vector2( 153.932, 96 )
 
 [node name="TopLeft" parent="Camera2D/Limits" index="0"]
-position = Vector2( -32, -32 )
+position = Vector2( -768, -328 )
 
 [node name="BottomRight" parent="Camera2D/Limits" index="1"]
-position = Vector2( 336, 192 )
+position = Vector2( 896, 512 )
 
 [node name="YSort" type="YSort" parent="."]
 


### PR DESCRIPTION
fix #21 

This PR adds expansion(visual) to the game world so that:
- more objects can be accomodated in the same scene
- player/enemy has more ground to cover